### PR TITLE
make assignment of URL consistent

### DIFF
--- a/quickget
+++ b/quickget
@@ -178,14 +178,13 @@ function check_links() {
       else
         if [[ $(type -t "editions_${FUNC}") == function ]]; then
             for EDITY in $("editions_${FUNC}"); do
-            URL=$(get_"${FUNC}" | cut -d " " -f1)
+            URL=$(get_"${OSORUBUNTU}" | cut -d " " -f1)
             CHECK=$(curl -o /dev/null --silent --head -L --write-out '%{http_code}\t%{content_type}' "${URL}")
             if [[ -n "${ZCHECK}" ]] ; then
                 ZCHECK=$(curl -o /dev/null --silent --head -L --write-out '%{http_code}\t%{content_type}' "${URL}.zsync")
                 echo "$FUNC $RELEASE $EDITY ${ZCHECK} ${URL}.zsync"
             fi
             echo "$FUNC $RELEASE $EDITY ${CHECK} $URL"
-
             done
         else
             URL=$(get_"${OSORUBUNTU}" | cut -d " " -f1)


### PR DESCRIPTION
The tweak to make all ubuntus call get_ubuntu() pedantically should be in both parts to potentially allow the block to be refactored.
Cannot do that (yet) because it messes the output, but ...
